### PR TITLE
Added function create_collector_group

### DIFF
--- a/fortiedr/fortiedr.py
+++ b/fortiedr/fortiedr.py
@@ -97,6 +97,20 @@ class Administrator:
 		}
 		return fortiedr_connection.insert(url, license)
 
+	'''
+	class Administrator: Create collector group
+	'''
+	def create_collector_group(self, organization : str, collectorGroupName : str) -> tuple[bool, None]:
+		url = '/management-rest/inventory/create-collector-group'
+		url_params = []
+		if organization:
+			url_params.append(f'organization={organization}')
+		if collectorGroupName:
+			url_params.append(f'name={collectorGroupName}')	
+		url += '?' + '&'.join(url_params)	
+		return fortiedr_connection.send(url)
+	
+	
 class Audit:
 
 	'''


### PR DESCRIPTION
As part of integrating EMS with EDR, EMS needs to create collector groups in the EDR system. I've added a new function that invokes the EDR RESTful API to create collector groups and tested it on a demo EDR system.